### PR TITLE
add an output for videos in ndarray for for wandb logger

### DIFF
--- a/src/dowel/wandb_output.py
+++ b/src/dowel/wandb_output.py
@@ -114,6 +114,9 @@ class WandBOutput(LogOutput):
             hist = np.histogram(value.rvs(self._histogram_samples))
             wandb_hist = wandb.Histogram(hist)
             wandb.log({key: wandb_hist}, step=step)
+        if isinstance(value, np.ndarray):
+            # If a numpy array is supplied we assume the dimensions are, in order: time, channels, width, height
+            wandb.log( {key: wandb.Video(value, fps=60, format="gif")})
         elif isinstance(value, Histogram):
             hist = np.histogram(value)
             wandb_hist = wandb.Histogram(hist)


### PR DESCRIPTION
This adds a handler for videos in a ndarray format to the wandb logger.